### PR TITLE
Update Dockerfile with rsync dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
 FROM debian:stable-slim
 
 # install dependencies
-RUN apt update && apt upgrade -y
-RUN apt install openssh-server vim sudo -y
+RUN apt-get update && apt-get install -y \
+    openssh-server \
+    rsync \
+    sudo \
+    vim \
+    && rm -rf /var/lib/apt/lists/*
 
 # set password for root user
 RUN echo 'root:yabe' | chpasswd

--- a/docker-networks.py
+++ b/docker-networks.py
@@ -114,4 +114,4 @@ def cleanup():
 
 
 atexit.register(cleanup)
-input("Present enter to stop workers")
+input("Press enter to stop workers")


### PR DESCRIPTION
## Changes

 - Add missing rsync dependency (fixes #12)
 - Use `apt-get` instead of `apt` since the latter is more suited as a user facing tool
 - Cleared apt lists after installing to reduce container size
 - Fix one small typo in `docker-networks.py`

Used [this](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#sort-multi-line-arguments) as a reference.